### PR TITLE
Switch to Boost Coroutine2 for good

### DIFF
--- a/examples/coroutine_01/main.cpp
+++ b/examples/coroutine_01/main.cpp
@@ -1,7 +1,7 @@
-#include <boost/coroutine/all.hpp>
+#include <boost/coroutine2/all.hpp>
 #include <iostream>
 
-using namespace boost::coroutines;
+using namespace boost::coroutines2;
 
 void cooperative(coroutine<void>::push_type &sink)
 {

--- a/examples/coroutine_02/main.cpp
+++ b/examples/coroutine_02/main.cpp
@@ -1,8 +1,8 @@
-#include <boost/coroutine/all.hpp>
+#include <boost/coroutine2/all.hpp>
 #include <functional>
 #include <iostream>
 
-using boost::coroutines::coroutine;
+using boost::coroutines2::coroutine;
 
 void cooperative(coroutine<int>::push_type &sink, int i)
 {
@@ -14,8 +14,7 @@ void cooperative(coroutine<int>::push_type &sink, int i)
 
 int main()
 {
-  using std::placeholders::_1;
-  coroutine<int>::pull_type source{std::bind(cooperative, _1, 0)};
+  coroutine<int>::pull_type source{[](auto &x){ cooperative(x, 0); }};
   std::cout << source.get() << '\n';
   source();
   std::cout << source.get() << '\n';

--- a/examples/coroutine_03/main.cpp
+++ b/examples/coroutine_03/main.cpp
@@ -1,9 +1,9 @@
-#include <boost/coroutine/all.hpp>
+#include <boost/coroutine2/all.hpp>
 #include <tuple>
 #include <string>
 #include <iostream>
 
-using boost::coroutines::coroutine;
+using boost::coroutines2::coroutine;
 
 void cooperative(coroutine<std::tuple<int, std::string>>::pull_type &source)
 {

--- a/examples/coroutine_04/main.cpp
+++ b/examples/coroutine_04/main.cpp
@@ -1,8 +1,8 @@
-#include <boost/coroutine/all.hpp>
+#include <boost/coroutine2/all.hpp>
 #include <stdexcept>
 #include <iostream>
 
-using boost::coroutines::coroutine;
+using boost::coroutines2::coroutine;
 
 void cooperative(coroutine<void>::push_type &sink)
 {


### PR DESCRIPTION
Das Kapitel https://dieboostcppbibliotheken.de/boost.coroutine
hat schon diese Anmerkung:

> [..] In diesem Kapitel lernen Sie die zweite Version kennen, [..]

Allerdings verwendeten die Beispiele noch Version 1.

This change eliminates scary Boost deprecation warnings
when compiling the exaples, e.g.  with Boost 1.64:

    /usr/include/boost/coroutine/detail/config.hpp:17:4:
    warning: #warning "Boost.Coroutine is now deprecated. Please
    switch to Boost.Coroutine2. To disable this warning message,
    define BOOST_COROUTINES_NO_DEPRECATION_WARNING." [-Wcpp]